### PR TITLE
Upgrade to Rust edition 2018.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "devolutions-jet"
 version = "0.1.0"
+edition = "2018"
 readme = "README.md"
 license = "MIT/Apache-2.0"
 authors = ["François Dubois <fdubois@devolutions.net>",
            "Marc-André Moreau <mamoreau@devolutions.net>"]
 
 [dependencies]
-log = "0.3"
-clap = "2.31.1"
+log = "0.4.6"
+clap = "2.32"
 url = "1.7.1"
 lazy_static = "1.2.0"
 futures = "0.1"

--- a/jet-proto/Cargo.toml
+++ b/jet-proto/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "jet-proto"
 version = "0.1.0"
+edition = "2018"
 authors = ["Francois Dubois <fdubois@devolutions.net>"]
 
 [dependencies]
-log = "0.3"
+log = "0.4.6"
 byteorder = "1.2.7"
 uuid = {version = "0.7.1", features = ["v4"]}

--- a/jet-proto/src/lib.rs
+++ b/jet-proto/src/lib.rs
@@ -253,7 +253,7 @@ fn error_other(desc: &str) -> io::Error {
 }
 
 fn apply_mask(mask: u8, payload: &mut [u8]) {
-    for mut byte in payload {
+    for byte in payload {
         *byte ^= mask;
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,4 @@
-use clap::App;
-use clap::Arg;
+use clap::{App, Arg, crate_name, crate_version};
 
 pub struct Config {
     listener_url: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,16 @@
-#[macro_use]
-extern crate log;
-extern crate env_logger;
-#[macro_use]
-extern crate clap;
-extern crate url;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate futures;
-extern crate byteorder;
-extern crate tokio;
-extern crate tokio_io;
-extern crate tokio_tcp;
-extern crate uuid;
-extern crate jet_proto;
-
 mod config;
 
 use std::collections::HashMap;
 use std::env;
 use std::io;
-use std::net::SocketAddr;
+use std::net::{SocketAddr, Shutdown};
 use std::str;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use std::time::Instant;
 
-use futures::future::{self, err, ok};
+use futures::{future, try_ready};
+use futures::future::{err, ok};
 use futures::stream::Forward;
 use futures::{Async, AsyncSink, Future, Sink, Stream};
 use tokio::runtime::{Runtime, TaskExecutor};
@@ -35,11 +19,12 @@ use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_tcp::{TcpListener, TcpStream};
 
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
+use lazy_static::lazy_static;
+use log::{debug, error, info};
+use url::Url;
 use uuid::Uuid;
 
-use config::Config;
-use std::net::Shutdown;
-use url::Url;
+use crate::config::Config;
 use jet_proto::{JetPacket, ResponseStatusCode};
 
 const ACCEPT_REQUEST_TIMEOUT_SEC: u64 = 5 * 60;


### PR DESCRIPTION
The clap and log dependencies were updated to simplify the import of macros and remove the macro_use statements.