### PR TITLE
Jet improvement

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -70,7 +70,7 @@ impl Config {
                 .number_of_values(1)
             )
             .arg(Arg::with_name("jet-instance")
-                .long("jet_instance")
+                .long("jet-instance")
                 .value_name("JET_INSTANCE")
                 .help("Specific name to reach that instance of JET.")
                 .takes_value(true)
@@ -78,7 +78,7 @@ impl Config {
             .arg(
                 Arg::with_name("routing-url")
                     .short("r")
-                    .long("routing_url")
+                    .long("routing-url")
                     .value_name("ROUTING_URL")
                     .help("An address on which the server will route all packets. Format: <scheme>://<ip>:<port>.")
                     .long_help("An address on which the server will route all packets. Format: <scheme>://<ip>:<port>. Scheme supported : tcp and tls. If it is not specified, the JET protocol will be used.")
@@ -88,7 +88,7 @@ impl Config {
             .arg(
                 Arg::with_name("pcap-filename")
                     .short("f")
-                    .long("pcap_file")
+                    .long("pcap-file")
                     .value_name("PCAP_FILENAME")
                     .help("Path of the file where the pcap file will be saved. If not set, no pcap file will be created. WaykNow and RDP protocols can be saved.")
                     .long_help("Path of the file where the pcap file will be saved. If not set, no pcap file will be created. WaykNow and RDP protocols can be saved.")
@@ -109,7 +109,7 @@ impl Config {
             .arg(
                 Arg::with_name("identities-file")
                     .short("i")
-                    .long("identities_file")
+                    .long("identities-file")
                     .value_name("IDENTITIES_FILE")
                     .help("A JSON-file with a list of identities: proxy credentials, target credentials, and target destination")
                     .long_help(r###"

--- a/src/http/controllers/jet.rs
+++ b/src/http/controllers/jet.rs
@@ -29,7 +29,7 @@ impl JetController {
     pub fn new(config: Config, jet_associations: JetAssociationsMap, executor_handle: TaskExecutor) -> Self {
         let dispatch = ControllerDispatch::new(ControllerData {config, jet_associations, executor_handle});
         dispatch.add(Method::POST, "/association/<association_id>", ControllerData::create_association);
-        dispatch.add(Method::POST, "/gather/<association_id>", ControllerData::gather_candidate);
+        dispatch.add(Method::POST, "/association/<association_id>/candidates", ControllerData::gather_association_candidates);
 
         JetController { dispatch }
     }
@@ -77,7 +77,7 @@ impl ControllerData {
         }
     }
 
-    fn gather_candidate(&self, req: &SyncRequest, res: &mut SyncResponse) {
+    fn gather_association_candidates(&self, req: &SyncRequest, res: &mut SyncResponse) {
         res.status(StatusCode::BAD_REQUEST);
 
         if let Some(association_id) = req.captures().get("association_id") {

--- a/src/http/middlewares/auth.rs
+++ b/src/http/middlewares/auth.rs
@@ -1,0 +1,84 @@
+use saphir::*;
+use log::error;
+use crate::config::Config;
+
+pub struct AuthMiddleware {
+    config: Config
+}
+
+impl AuthMiddleware {
+    pub fn new(config: Config) -> Self {
+        AuthMiddleware {
+            config
+        }
+    }
+}
+
+impl Middleware for AuthMiddleware {
+    fn resolve(&self, req: &mut SyncRequest, res: &mut SyncResponse) -> RequestContinuation {
+        if let Some(api_key) = self.config.api_key() {
+            let auth_header = match req.headers_map().get(header::AUTHORIZATION) {
+                Some(h) => h.clone(),
+                None => {
+                    error!("Authorization header not present in request.");
+                    res.status(StatusCode::UNAUTHORIZED);
+                    return RequestContinuation::Stop;
+                }
+            };
+
+            let auth_str = match auth_header.to_str() {
+                Ok(s) => s,
+                Err(_) => {
+                    error!("Authorization header wrong format");
+                    res.status(StatusCode::UNAUTHORIZED);
+                    return RequestContinuation::Stop;
+                }
+            };
+
+            match parse_auth_header(auth_str) {
+                Some((AuthHeaderType::Bearer, token)) => {
+                    // API_KEY
+                    if let Some(api_key) = self.config.api_key() {
+                        if api_key == token {
+                            return RequestContinuation::Continue;
+                        }
+                    }
+                }
+                _ => {
+                    error!("Invalid authorization type");
+                }
+            }
+
+            res.status(StatusCode::UNAUTHORIZED);
+            RequestContinuation::Stop
+
+        } else {
+            // API_KEY not defined, we accept everything
+            RequestContinuation::Continue
+        }
+    }
+}
+
+#[derive(PartialEq)]
+pub enum AuthHeaderType{
+    Basic,
+    Bearer,
+    Signature,
+}
+
+pub fn parse_auth_header(auth_header: &str) -> Option<(AuthHeaderType, String)>{
+    let auth_vec = auth_header.trim().split(' ').collect::<Vec<&str>>();
+
+    if auth_vec.len() == 2 {
+        return match auth_vec[0].to_lowercase().as_ref(){
+            "basic" => Some((AuthHeaderType::Basic, auth_vec[1].to_string())),
+            "bearer" => Some((AuthHeaderType::Bearer, auth_vec[1].to_string())),
+            "signature" =>Some((AuthHeaderType::Signature, auth_vec[1].to_string())),
+            _ => None
+        };
+    }
+
+    None
+}
+
+

--- a/src/http/middlewares/auth.rs
+++ b/src/http/middlewares/auth.rs
@@ -38,10 +38,8 @@ impl Middleware for AuthMiddleware {
             match parse_auth_header(auth_str) {
                 Some((AuthHeaderType::Bearer, token)) => {
                     // API_KEY
-                    if let Some(api_key) = self.config.api_key() {
-                        if api_key == token {
-                            return RequestContinuation::Continue;
-                        }
+                    if api_key == token {
+                        return RequestContinuation::Continue;
                     }
                 }
                 _ => {

--- a/src/http/middlewares/mod.rs
+++ b/src/http/middlewares/mod.rs
@@ -1,0 +1,1 @@
+pub mod auth;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,2 +1,3 @@
 pub mod controllers;
 pub mod http_server;
+pub mod middlewares;

--- a/src/jet/association.rs
+++ b/src/jet/association.rs
@@ -49,8 +49,8 @@ impl Association {
         for (id, candidate) in &self.candidates {
             if let Some(url) = candidate.url() {
                 let json_candidate = json!({
-                    "url": url.to_string(),
-                    "id": id.to_string()
+                    "id": id.to_string(),
+                    "url": url.to_string()
                 });
 
                 candidate_list.push(json_candidate);

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -28,17 +28,17 @@ pub fn run_proxy(proxy_addr: &str, websocket_url: Option<&str>, routing_url: Opt
     let cmd_line_arg = format!("tcp://{}", proxy_addr);
     proxy_command.arg("-l").arg(cmd_line_arg);
 
-    proxy_command.arg("--jet_instance").arg("127.0.0.1");
+    proxy_command.arg("--jet-instance").arg("127.0.0.1");
 
     if let Some(websocket_url) = websocket_url {
         proxy_command.arg("-l").arg(websocket_url);
     }
     if routing_url.is_some() {
-        proxy_command.arg("--routing_url").arg(routing_url.unwrap());
+        proxy_command.arg("--routing-url").arg(routing_url.unwrap());
     }
 
     if identities_file.is_some() {
-        proxy_command.arg("--identities_file").arg(identities_file.unwrap());
+        proxy_command.arg("--identities-file").arg(identities_file.unwrap());
     }
 
     let proxy = proxy_command.spawn().unwrap();


### PR DESCRIPTION
Changes:
- Fixed the command line parameters (use - instead of _.  jet-instance and not jet_instance for example)
- Added api_key. If provided, call to POST /jet/association/<id> has to contain the api_key. If not provided, all calls are accepted.  Env variable : JET_API_KEY or --api-key on command line
- The route /jet/gater/<id> is now /jet/association/<id>/candidates
