### PR TITLE
Accept external url on command line

### DIFF
--- a/src/http/controllers/jet.rs
+++ b/src/http/controllers/jet.rs
@@ -88,7 +88,7 @@ impl ControllerData {
 
                         if association.get_candidates().len() == 0 {
                             for listener in self.config.listeners() {
-                                if let Some(candidate) = Candidate::new(&format!("{}://{}:{}", listener.scheme(), self.config.jet_instance(), listener.port_or_known_default().unwrap_or(8080))) {
+                                if let Some(candidate) = Candidate::new(&listener.external_url.to_string().trim_end_matches("/")) {
                                     association.add_candidate(candidate);
                                 }
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,10 +59,21 @@ lazy_static! {
 fn main() {
     env_logger::init();
     let config = Config::init();
+
     let listeners = config.listeners();
 
-    let tcp_listeners: Vec<&Url> = listeners.iter().filter(|listener| listener.scheme() == "tcp").collect();
-    let websocket_listeners: Vec<&Url> = listeners.iter().filter(|listener| listener.scheme() == "ws" || listener.scheme() == "wss").collect();
+    let tcp_listeners: Vec<Url> = listeners.iter().filter_map(|listener| {
+        if listener.url.scheme() == "tcp" {
+            return Some(listener.url.clone());
+        }
+        None
+    }).collect();
+    let websocket_listeners: Vec<Url> = listeners.iter().filter_map(|listener| {
+        if listener.url.scheme() == "ws" || listener.url.scheme() == "wss" {
+            return Some(listener.url.clone());
+        }
+        None
+    }).collect();
 
     // Initialize the various data structures we're going to use in our server.
     let jet_associations: JetAssociationsMap = Arc::new(Mutex::new(HashMap::new()));


### PR DESCRIPTION
You can now specify the external url for a listener. You can specify it with the listener, separated with a comma

**-l tcp://0.0.0.0:8080**
The external url will be tcp://JET_INSTANCE:8080 where JET_INSTANCE is the value of jet-instance parameter

**-l tcp://0.0.0.0:8080,tcp://jet.io:8080**
The external url will be tcp://jet.io:8080

**-l tcp://0.0.0.0:8080,tcp://<jet_intance>:8080**
The external url will be tcp://JET_INSTANCE:8080 where JET_INSTANCE is the value of jet-instance parameter
 