### PR TITLE
Added env. variable JET_LISTENERS to add a list of listeners

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -278,6 +278,16 @@ impl ConfigTemp {
                 self.unrestricted = val;
             }
         }
+
+        if let Ok(val) = env::var("JET_LISTENERS") {
+            self.listeners = val.split(";").filter_map(|item: &str| {
+                if !item.is_empty() {
+                    Some(item.to_string())
+                } else {
+                    None
+                }
+            }).collect();
+        }
     }
 }
 


### PR DESCRIPTION
You can specify a list of listeners, separated with ;

Example : 

JET_LISTENERS=tcp://0.0.0.0:8080,tcp://<jet_instance>:8080;ws://0.0.0.0:9090,wss://<jet_instance>:443