### PR TITLE
Logs optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "1.0"
 slog = { version = "2.5", features = ["max_level_trace","release_max_level_trace"] }
 slog-term = "2.4"
 slog-async = "2.3"
-slog-scope = "4.1"
+slog-scope = "4.3"
 slog-scope-futures = { git = "https://gitlab.com/Fotosmile/slog-scope-futures.git" }
 chrono = { version = "0.4", features = ["serde"] }
 failure = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ saphir = { version = "0.9.5", features = ["https", "request_handler"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-slog = { version = "2.5", features = ["max_level_trace","release_max_level_trace"] }
+slog = { version = "2.5", features = ["max_level_trace","release_max_level_debug"] }
 slog-term = "2.4"
 slog-async = "2.3"
 slog-scope = "4.3"

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,0 +1,118 @@
+use std::{io, path::PathBuf, sync::atomic::Ordering};
+
+use futures::{Future, Stream};
+use slog_scope::{info, warn};
+
+use crate::{
+    config::{Config, Protocol},
+    interceptor::{pcap::PcapInterceptor, rdp::RdpMessageReader, UnknownMessageReader, WaykMessageReader},
+    transport::Transport,
+    SESSION_IN_PROGRESS_COUNT,
+};
+
+pub struct Proxy {
+    config: Config,
+}
+
+impl Proxy {
+    pub fn new(config: Config) -> Self {
+        Proxy { config }
+    }
+
+    pub fn build<T: Transport, U: Transport>(
+        &self,
+        server_transport: T,
+        client_transport: U,
+    ) -> Box<dyn Future<Item = (), Error = io::Error> + Send> {
+        let jet_sink_server = server_transport.message_sink();
+        let mut jet_stream_server = server_transport.message_stream();
+
+        let jet_sink_client = client_transport.message_sink();
+        let mut jet_stream_client = client_transport.message_stream();
+
+        if let Some(pcap_files_path) = self.config.pcap_files_path() {
+            let server_peer_addr = jet_stream_server.peer_addr().unwrap();
+            let client_peer_addr = jet_stream_client.peer_addr().unwrap();
+
+            let filename = format!(
+                "{}({})-to-{}({})-at-{}.pcap",
+                client_peer_addr.ip(),
+                client_peer_addr.port(),
+                server_peer_addr.ip().to_string(),
+                server_peer_addr.port(),
+                chrono::Utc::now().format("%Y-%m-%d_%H-%M-%S")
+            );
+            let mut path = PathBuf::from(pcap_files_path);
+            path.push(filename);
+
+            let mut interceptor = PcapInterceptor::new(
+                server_peer_addr,
+                client_peer_addr,
+                path.to_str().expect("path to pcap files must be valid"),
+            );
+
+            match self.config.protocol() {
+                Protocol::WAYK => {
+                    info!("WaykMessageReader will be used to interpret application protocol.");
+                    interceptor.set_message_reader(WaykMessageReader::get_messages);
+                }
+                Protocol::RDP => {
+                    info!("RdpMessageReader will be used to interpret application protocol");
+                    interceptor.set_message_reader(RdpMessageReader::get_messages);
+                }
+                Protocol::UNKNOWN => {
+                    warn!("Protocol is unknown. Data received will not be split to get application message.");
+                    interceptor.set_message_reader(UnknownMessageReader::get_messages);
+                }
+            }
+
+            jet_stream_server.set_packet_interceptor(Box::new(interceptor.clone()));
+            jet_stream_client.set_packet_interceptor(Box::new(interceptor.clone()));
+        }
+
+        // Build future to forward all bytes
+        let f1 = jet_stream_server.forward(jet_sink_client);
+        let f2 = jet_stream_client.forward(jet_sink_server);
+
+        SESSION_IN_PROGRESS_COUNT.fetch_add(1, Ordering::Relaxed);
+
+        Box::new(f1.and_then(|(mut jet_stream, mut jet_sink)| {
+            // Shutdown stream and the sink so the f2 will finish as well (and the join future will finish)
+            let _ = jet_stream.shutdown();
+            let _ = jet_sink.shutdown();
+
+            Ok((jet_stream, jet_sink))
+        })
+            .join(f2.and_then(|(mut jet_stream, mut jet_sink)| {
+                // Shutdown stream and the sink so the f2 will finish as well (and the join future will finish)
+                let _ = jet_stream.shutdown();
+                let _ = jet_sink.shutdown();
+
+                Ok((jet_stream, jet_sink))
+            }))
+            .and_then(|((jet_stream_1, jet_sink_1), (jet_stream_2, jet_sink_2))| {
+                let server_addr = jet_stream_1
+                    .peer_addr()
+                    .map(|addr| addr.to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
+                let client_addr = jet_stream_2
+                    .peer_addr()
+                    .map(|addr| addr.to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
+                info!(
+                    "Proxy result : {} bytes read on {server} and {} bytes written on {client}. {} bytes read on {client} and {} bytes written on {server}",
+                    jet_stream_1.nb_bytes_read(),
+                    jet_sink_1.nb_bytes_written(),
+                    jet_stream_2.nb_bytes_read(),
+                    jet_sink_2.nb_bytes_written(),
+                    server = &server_addr,
+                    client = &client_addr
+                );
+
+                Ok(())
+            }).then(|result| {
+            SESSION_IN_PROGRESS_COUNT.fetch_sub(1, Ordering::Relaxed);
+            result
+        }))
+    }
+}

--- a/src/rdp/sequence_future/negotiation.rs
+++ b/src/rdp/sequence_future/negotiation.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use ironrdp::nego::{FailureCode, NegoData, Request, Response, ResponseData, ResponseFlags, SecurityProtocol};
-use slog_scope::{debug, info};
+use slog_scope::debug;
 use tokio::codec::Framed;
 use tokio_tcp::TcpStream;
 
@@ -31,7 +31,7 @@ impl SequenceFutureProperties<TcpStream, NegotiationWithClientTransport> for Neg
             Some(NegoData::Cookie(cookie)) => (None, Some(cookie)),
             None => (None, None),
         };
-        info!(
+        debug!(
             "Processing negotiation request from the client (routing_token: {:?}, cookie: {:?}, protocol: {:?}, flags: {:?})",
             routing_token, cookie, request.protocol, request.flags,
         );
@@ -76,7 +76,7 @@ impl SequenceFutureProperties<TcpStream, NegotiationWithClientTransport> for Neg
         mut client: Option<Framed<TcpStream, NegotiationWithClientTransport>>,
         _server: Option<Framed<TcpStream, NegotiationWithClientTransport>>,
     ) -> Self::Item {
-        info!("Successfully negotiated with the client");
+        debug!("Successfully negotiated with the client");
 
         (
             client
@@ -117,7 +117,7 @@ impl SequenceFutureProperties<TcpStream, NegotiationWithServerTransport> for Neg
     fn process_pdu(&mut self, response: Response) -> io::Result<Option<Request>> {
         match response.response {
             Some(ResponseData::Response { protocol, flags }) => {
-                info!(
+                debug!(
                     "Received negotiation response from the server (protocol: {:?}, flags: {:?})",
                     protocol, flags,
                 );
@@ -146,7 +146,7 @@ impl SequenceFutureProperties<TcpStream, NegotiationWithServerTransport> for Neg
         _client: Option<Framed<TcpStream, NegotiationWithServerTransport>>,
         mut server: Option<Framed<TcpStream, NegotiationWithServerTransport>>,
     ) -> Self::Item {
-        info!("Successfully negotiated with the server");
+        debug!("Successfully negotiated with the server");
 
         (
             server

--- a/src/transport/ws.rs
+++ b/src/transport/ws.rs
@@ -9,7 +9,7 @@ use crate::interceptor::PacketInterceptor;
 use futures::{Async, Stream, Sink, AsyncSink, Future};
 use crate::transport::{Transport, JetStreamType, JetSinkType, JetFuture, JetStream, JetSink};
 use url::Url;
-use slog_scope::{debug, error};
+use slog_scope::{trace, error};
 use std::net::SocketAddr;
 use std::io::Cursor;
 use tungstenite::Message;
@@ -545,15 +545,15 @@ impl Sink for WsJetSink {
         mut item: <Self as Sink>::SinkItem,
     ) -> Result<AsyncSink<<Self as Sink>::SinkItem>, <Self as Sink>::SinkError> {
         if let Ok(mut stream) = self.stream.try_lock() {
-            debug!("{} bytes to write on {}", item.len(), stream.peer_addr().unwrap());
+            trace!("{} bytes to write on {}", item.len(), stream.peer_addr().unwrap());
             match stream.poll_write(&item) {
                 Ok(Async::Ready(len)) => {
                     if len > 0 {
                         self.nb_bytes_written.fetch_add(len as u64, Ordering::SeqCst);
                         item.drain(0..len);
-                        debug!("{} bytes written on {}", len, stream.peer_addr().unwrap())
+                        trace!("{} bytes written on {}", len, stream.peer_addr().unwrap())
                     } else {
-                        debug!("0 bytes written on {}", stream.peer_addr().unwrap())
+                        trace!("0 bytes written on {}", stream.peer_addr().unwrap())
                     }
 
                     if item.is_empty() {


### PR DESCRIPTION
The first batch of changes for Jet optimization:
1. Proxy moved out to the separate module;
2. Added LevelFilter to the AsyncDrain, so now Jet does not rain "channel overflow" messages to logs. The performance was improved by up to 25%;
3. Replaced debug logs in RDP connection sequence and in the "hot" places (such as TcpJetStream::poll, TcpJetSink::start_send) with trace logs, removed trace logs from release builds. Thus, a release build will not spend time to canceled trace logs, which can be viewed at any time in debug builds :) The performance was improved by up to 15%. @fdubois1 are you agree with these changes?