### PR TITLE
Added option to get candidate details when we get association list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,7 @@ dependencies = [
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -414,6 +415,7 @@ dependencies = [
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tungstenite 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "x509-parser 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2268,6 +2270,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "url_serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2707,6 +2718,7 @@ dependencies = [
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
+"checksum url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74e7d099f1ee52f823d4bdd60c93c3602043c728f5db3b97bdb548467f7bddea"
 "checksum utf-8 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ authors = ["François Dubois <fdubois@devolutions.net>",
 [dependencies]
 clap = "2.32"
 url = "1.7.1"
+url_serde = "0.2.0"
 lazy_static = "1.2.0"
 futures = "0.1"
 tokio = "0.1.22"
@@ -29,6 +30,7 @@ saphir = { version = "0.9.5", features = ["https", "request_handler"] }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+serde_urlencoded = "0.5.3"
 slog = { version = "2.5", features = ["max_level_trace","release_max_level_debug"] }
 slog-term = "2.4"
 slog-async = "2.3"

--- a/src/jet.rs
+++ b/src/jet.rs
@@ -4,7 +4,7 @@ use jet_proto::Error;
 pub mod association;
 pub mod candidate;
 
-#[derive(Debug,Clone,PartialEq)]
+#[derive(Serialize, Deserialize, Debug,Clone,PartialEq)]
 pub enum TransportType {
     Tcp,
     Tls,

--- a/src/jet/candidate.rs
+++ b/src/jet/candidate.rs
@@ -5,6 +5,35 @@ use slog_scope::error;
 use crate::jet::TransportType;
 use crate::transport::JetTransport;
 
+#[derive(Serialize, Deserialize)]
+pub struct CandidateResponse {
+    id: Uuid,
+    #[serde(with = "url_serde")]
+    url: Option<Url>,
+    state: CandidateState,
+    association_id: Uuid,
+    transport_type: TransportType,
+    bytes_sent: u64,
+    bytes_recv: u64,
+}
+
+impl From<Candidate> for CandidateResponse {
+    fn from(c: Candidate) -> Self {
+        let (bytes_sent, bytes_recv) =
+            c.client_transport.map(|transport|(transport.get_nb_bytes_read(), transport.get_nb_bytes_written()))
+                .unwrap_or((0, 0));
+
+        CandidateResponse {
+            id: c.id,
+            url: c.url,
+            state: c.state,
+            association_id: c.association_id,
+            transport_type: c.transport_type,
+            bytes_sent,
+            bytes_recv,
+        }
+    }
+}
 #[derive(Clone)]
 pub struct Candidate {
     id: Uuid,


### PR DESCRIPTION
We can now add a query param when we get all associations.  We add ?detail=true to get something like this :

[
  {
    "id": "815d02a7-7316-41d5-8111-43bc9ffc8f00",
    "version": 2,
    "bytes_sent": 720,
    "bytes_recv": 1712,
    "candidates": [
      {
        "id": "055a01aa-bd34-42c5-b6fe-19aa18afc6e8",
        "url": "tcp://10.1.21.112:8080/",
        "state": "Connected",
        "association_id": "815d02a7-7316-41d5-8111-43bc9ffc8f00",
        "transport_type": "Tcp",
        "bytes_sent": 720,
        "bytes_recv": 1712
      },
      {
        "id": "c4173e98-8c80-4eb6-8046-ca5721ed7e35",
        "url": "tcp://10.1.21.112:8081/",
        "state": "Final",
        "association_id": "815d02a7-7316-41d5-8111-43bc9ffc8f00",
        "transport_type": "Tcp",
        "bytes_sent": 0,
        "bytes_recv": 0
      },
      {
        "id": "47c6877b-910b-4a06-9677-144b6ff3c014",
        "url": "wss://566c2e8f.ngrok.io/",
        "state": "Final",
        "association_id": "815d02a7-7316-41d5-8111-43bc9ffc8f00",
        "transport_type": "Wss",
        "bytes_sent": 0,
        "bytes_recv": 0
      }
    ],
    "creation_timestamp": 1575310968
  }
]