### PR TITLE
Version bump from 0.8.0 to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "devolutions-jet"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devolutions-jet"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 readme = "README.md"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Moving to 0.9.0 to deploy a new jet version soon