### PR TITLE
Move the code in a library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,27 @@
+#[macro_use]
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
+
+use std::sync::atomic::AtomicU64;
+
+use lazy_static::lazy_static;
+
+pub mod config;
+pub mod http;
+pub mod interceptor;
+pub mod jet;
+pub mod jet_client;
+pub mod logger;
+pub mod proxy;
+pub mod rdp;
+pub mod routing_client;
+pub mod transport;
+pub mod utils;
+pub mod websocket_client;
+
+pub use proxy::Proxy;
+
+lazy_static! {
+    pub static ref SESSION_IN_PROGRESS_COUNT: AtomicU64 = AtomicU64::new(0);
+}


### PR DESCRIPTION
This is to deal with a limitation of cargo-fuzz, fuzzers can only use code from librairies. The workaround is to move the code to lib.rs and import it in main.rs. I'm currently working on fuzzers, they will be added in another pull request.

Tests are passing with the exception of `rdp_with_nla_ntlm` which is also failing on the master branch.