### PR TITLE
Add curl to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "Devolutions Inc."
 WORKDIR /opt/wayk
 
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends libssl1.1
+RUN apt-get install -y --no-install-recommends ca-certificates curl
 RUN rm -rf /var/lib/apt/lists/*
 
 COPY devolutions-jet .


### PR DESCRIPTION
Add ca-certificates package while we are at it, and remove libssl1.1 as it shouldn't be needed (unless pulled by curl again, but only as an indirect dependency).

Adding curl is necessary to use it for Docker health check commands like in the other containers we have.