### PR TITLE
Added module in log + version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "devolutions-jet"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devolutions-jet"
-version = "0.10.3"
+version = "0.10.4"
 edition = "2018"
 readme = "README.md"
 license = "MIT/Apache-2.0"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -57,7 +57,12 @@ pub fn init(file_path: Option<&String>) -> io::Result<Logger> {
             .fuse()
     };
     let drain = LevelFilter::new(async_drain, log_level).fuse();
-    let logger = Logger::root(drain, o!());
+    let logger = Logger::root(
+        drain,
+        o!("module" => slog::FnValue(move |info| {
+            format!("[{}]", info.module())
+        })),
+    );
 
     if log_level_result.is_err() {
         warn!(


### PR DESCRIPTION
Dorenavant, les traces ressembleront a ceci (ajout du module a la fin): 

2020-05-11 09:53:39:951218 INFO Configuring http router, **module: [devolutions_jet::http::http_server]**
2020-05-11 09:53:39:951591 INFO Saphir successfully started and listening on http://0.0.0.0:10256/, **module: [saphir::server]**
