### PR TITLE
CI test script runnability fixes

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,18 +1,20 @@
 #![allow(unused_variables)]
 #![allow(unused_imports)]
 
-use byteorder::LittleEndian;
-use byteorder::WriteBytesExt;
-use jet_proto::accept::{JetAcceptReq, JetAcceptRsp};
-use jet_proto::connect::JetConnectReq;
-use jet_proto::{JetMessage, JET_VERSION_V1};
-use std::env;
-use std::io::{self, Cursor, Error, Read, Write};
-use std::net::TcpListener;
-use std::net::TcpStream;
-use std::process;
-use std::str::FromStr;
-use std::thread;
+use byteorder::{LittleEndian, WriteBytesExt};
+use jet_proto::{
+    accept::{JetAcceptReq, JetAcceptRsp},
+    connect::JetConnectReq,
+    JetMessage, JET_VERSION_V1,
+};
+use std::{
+    env,
+    io::{self, Cursor, Error, Read, Write},
+    net::{TcpListener, TcpStream},
+    process,
+    str::FromStr,
+    thread,
+};
 use uuid::Uuid;
 
 type Port = u16;
@@ -125,14 +127,14 @@ fn main() {
     let jet_message = if let Some(uuid) = server_uuid {
         JetMessage::JetConnectReq(JetConnectReq {
             version: 1,
-            host: host,
+            host,
             association: uuid,
             candidate: Uuid::nil(),
         })
     } else {
         JetMessage::JetAcceptReq(JetAcceptReq {
             version: 1,
-            host: host,
+            host,
             association: Uuid::nil(),
             candidate: Uuid::nil(),
         })

--- a/examples/tool_invalid_packet.rs
+++ b/examples/tool_invalid_packet.rs
@@ -1,7 +1,4 @@
-use std::env;
-use std::io::Write;
-use std::net::TcpStream;
-use std::process;
+use std::{env, io::Write, net::TcpStream, process};
 
 type Port = u16;
 
@@ -60,6 +57,6 @@ fn main() {
 
     loop {
         let mut stream = TcpStream::connect((host.as_str(), port)).unwrap();
-        stream.write_all("This is junk".as_bytes()).unwrap();
+        stream.write_all(b"This is junk").unwrap();
     }
 }

--- a/jet-proto/src/accept.rs
+++ b/jet-proto/src/accept.rs
@@ -1,11 +1,11 @@
-use crate::utils::{RequestHelper, ResponseHelper};
 use crate::{
-    get_uuid_in_path, Error, JET_HEADER_ASSOCIATION, JET_HEADER_HOST, JET_HEADER_INSTANCE, JET_HEADER_METHOD,
-    JET_HEADER_TIMEOUT, JET_HEADER_VERSION,
+    get_uuid_in_path,
+    utils::{RequestHelper, ResponseHelper},
+    Error, JET_HEADER_ASSOCIATION, JET_HEADER_HOST, JET_HEADER_INSTANCE, JET_HEADER_METHOD, JET_HEADER_TIMEOUT,
+    JET_HEADER_VERSION,
 };
 use http::StatusCode;
-use std::io;
-use std::str::FromStr;
+use std::{io, str::FromStr};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/jet-proto/src/connect.rs
+++ b/jet-proto/src/connect.rs
@@ -1,11 +1,10 @@
-use crate::utils::{RequestHelper, ResponseHelper};
 use crate::{
-    get_uuid_in_path, Error, JET_HEADER_ASSOCIATION, JET_HEADER_CONNECTION, JET_HEADER_HOST, JET_HEADER_METHOD,
-    JET_HEADER_VERSION,
+    get_uuid_in_path,
+    utils::{RequestHelper, ResponseHelper},
+    Error, JET_HEADER_ASSOCIATION, JET_HEADER_CONNECTION, JET_HEADER_HOST, JET_HEADER_METHOD, JET_HEADER_VERSION,
 };
 use http::StatusCode;
-use std::io;
-use std::str::FromStr;
+use std::{io, str::FromStr};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq)]

--- a/jet-proto/src/lib.rs
+++ b/jet-proto/src/lib.rs
@@ -2,16 +2,21 @@ pub mod accept;
 pub mod connect;
 pub mod utils;
 
-use crate::accept::{JetAcceptReq, JetAcceptRsp};
-use crate::connect::{JetConnectReq, JetConnectRsp};
-use crate::utils::RequestHelper;
+use crate::{
+    accept::{JetAcceptReq, JetAcceptRsp},
+    connect::{JetConnectReq, JetConnectRsp},
+    utils::RequestHelper,
+};
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
 pub use http::StatusCode;
 use log::trace;
-use std::env;
-use std::io::Read;
-use std::io::{self};
-use std::sync::Once;
+use std::{
+    env,
+    io::{
+        Read, {self},
+    },
+    sync::Once,
+};
 use uuid::Uuid;
 
 pub const JET_MSG_SIGNATURE: u32 = 0x0054_454A;
@@ -189,7 +194,7 @@ impl JetMessage {
 }
 
 fn get_uuid_in_path(path: &str, index: usize) -> Option<Uuid> {
-    if let Some(raw_uuid) = path.split('/').skip(index + 1).next() {
+    if let Some(raw_uuid) = path.split('/').nth(index + 1) {
         Uuid::parse_str(raw_uuid).ok()
     } else {
         None
@@ -332,8 +337,7 @@ mod test {
 
     #[test]
     fn test_accept_v2() {
-        use std::io::Cursor;
-        use std::str::FromStr;
+        use std::{io::Cursor, str::FromStr};
 
         let mut cursor = Cursor::new(TEST_JET_ACCEPT_REQ_V2);
         let jet_message = JetMessage::read_request(&mut cursor).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -434,21 +434,21 @@ impl From<ConfigTemp> for Config {
                 let url_str = &listener[0..pos];
                 url = listener[0..pos]
                     .parse::<Url>()
-                    .expect(&format!("Listener {} is an invalid URL.", url_str));
+                    .unwrap_or_else(|_| panic!("Listener {} is an invalid URL.", url_str));
 
                 if listener.len() > pos + 1 {
                     let external_str = listener[pos + 1..].to_string();
                     let external_str = external_str.replace("<jet_instance>", &jet_instance);
                     external_url = external_str
                         .parse::<Url>()
-                        .expect(&format!("External_url {} is an invalid URL.", external_str));
+                        .unwrap_or_else(|_| panic!("External_url {} is an invalid URL.", external_str));
                 } else {
                     panic!("External url has to be specified after the comma : {}", listener);
                 }
             } else {
                 url = listener
                     .parse::<Url>()
-                    .expect(&format!("Listener {} is an invalid URL.", listener));
+                    .unwrap_or_else(|_| panic!("Listener {} is an invalid URL.", listener));
                 external_url = format!(
                     "{}://{}:{}",
                     url.scheme(),
@@ -456,7 +456,7 @@ impl From<ConfigTemp> for Config {
                     url.port_or_known_default().unwrap_or(8080)
                 )
                 .parse::<Url>()
-                .expect(&format!("External_url can't be built based on listener {}", listener));
+                .unwrap_or_else(|_| panic!("External_url can't be built based on listener {}", listener));
             }
 
             listeners.push(ListenerConfig { url, external_url });
@@ -469,7 +469,7 @@ impl From<ConfigTemp> for Config {
         let http_listener_url = temp
             .http_listener_url
             .parse::<Url>()
-            .expect(&format!("Http listener {} is an invalid URL", temp.http_listener_url));
+            .unwrap_or_else(|e| panic!("Http listener URL is invalid: {}", e));
 
         let pem_str = if let Some(pem) = temp.provisioner_public_key_pem {
             Some(pem)
@@ -483,8 +483,7 @@ impl From<ConfigTemp> for Config {
             let pem = pem_str
                 .parse::<Pem>()
                 .expect("couldn't parse provisioner public key pem");
-            let public_key = PublicKey::from_pem(&pem).expect("couldn't parse provisioner public key");
-            public_key
+            PublicKey::from_pem(&pem).expect("couldn't parse provisioner public key")
         });
 
         Config {

--- a/src/http/controllers/health.rs
+++ b/src/http/controllers/health.rs
@@ -1,6 +1,5 @@
 use crate::config::Config;
-use saphir::Method;
-use saphir::*;
+use saphir::{Method, *};
 use std::sync::Arc;
 
 struct ControllerData {

--- a/src/http/controllers/jet.rs
+++ b/src/http/controllers/jet.rs
@@ -1,19 +1,23 @@
 use jet_proto::JET_VERSION_V2;
-use saphir::Method;
-use saphir::*;
+use saphir::{Method, *};
 use slog_scope::info;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tokio::runtime::TaskExecutor;
 use uuid::Uuid;
 
-use crate::config::Config;
-use crate::http::controllers::health::build_health_response;
-use crate::http::controllers::utils::SyncResponseUtil;
-use crate::jet::association::{Association, AssociationResponse};
-use crate::jet::candidate::Candidate;
-use crate::jet_client::JetAssociationsMap;
-use crate::utils::association::{RemoveAssociation, ACCEPT_REQUEST_TIMEOUT_SEC};
+use crate::{
+    config::Config,
+    http::controllers::{health::build_health_response, utils::SyncResponseUtil},
+    jet::{
+        association::{Association, AssociationResponse},
+        candidate::Candidate,
+    },
+    jet_client::JetAssociationsMap,
+    utils::association::{RemoveAssociation, ACCEPT_REQUEST_TIMEOUT_SEC},
+};
 use futures::Future;
 use std::collections::HashMap;
 use tokio::timer::Delay;
@@ -139,7 +143,7 @@ impl ControllerData {
                     if association.get_candidates().is_empty() {
                         for listener in self.config.listeners() {
                             if let Some(candidate) =
-                                Candidate::new(&listener.external_url.to_string().trim_end_matches("/"))
+                                Candidate::new(&listener.external_url.to_string().trim_end_matches('/'))
                             {
                                 association.add_candidate(candidate);
                             }

--- a/src/http/controllers/sessions.rs
+++ b/src/http/controllers/sessions.rs
@@ -1,6 +1,5 @@
 use crate::SESSION_IN_PROGRESS_COUNT;
-use saphir::Method;
-use saphir::*;
+use saphir::{Method, *};
 use std::sync::atomic::Ordering;
 
 struct ControllerData {}
@@ -15,6 +14,12 @@ impl SessionsController {
         dispatch.add(Method::GET, "/count", sessions_count);
 
         SessionsController { dispatch }
+    }
+}
+
+impl Default for SessionsController {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/http/http_server.rs
+++ b/src/http/http_server.rs
@@ -1,15 +1,14 @@
-use crate::config::Config;
-use crate::http::controllers::health::HealthController;
-use crate::http::controllers::jet::JetController;
-use crate::http::controllers::sessions::SessionsController;
-use crate::http::middlewares::auth::AuthMiddleware;
-use crate::jet_client::JetAssociationsMap;
-use saphir::server::SslConfig;
-use saphir::Server as SaphirServer;
-use saphir::ServerSpawn;
+use crate::{
+    config::Config,
+    http::{
+        controllers::{health::HealthController, jet::JetController, sessions::SessionsController},
+        middlewares::auth::AuthMiddleware,
+    },
+    jet_client::JetAssociationsMap,
+};
+use saphir::{server::SslConfig, Server as SaphirServer, ServerSpawn};
 use slog_scope::info;
-use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tokio::runtime::TaskExecutor;
 
 pub struct HttpServer {

--- a/src/interceptor/pcap.rs
+++ b/src/interceptor/pcap.rs
@@ -1,13 +1,16 @@
-use packet::builder::Builder;
-use packet::ether::Builder as BuildEthernet;
-use packet::ether::Protocol;
-use packet::ip::v6::Builder as BuildV6;
-use packet::tcp::flag::Flags;
+use packet::{
+    builder::Builder,
+    ether::{Builder as BuildEthernet, Protocol},
+    ip::v6::Builder as BuildV6,
+    tcp::flag::Flags,
+};
 use pcap_file::PcapWriter;
 use slog_scope::{debug, error};
-use std::fs::File;
-use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
+use std::{
+    fs::File,
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
 
 use crate::interceptor::{MessageReader, PacketInterceptor, PduSource, PeerInfo, UnknownMessageReader};
 

--- a/src/interceptor/rdp/tests.rs
+++ b/src/interceptor/rdp/tests.rs
@@ -107,10 +107,10 @@ fn does_not_read_incomplete_packet_on_multiple_calls() {
     let mut data = TPKT_CLIENT_CONNECTION_REQUEST_PACKET.to_vec();
     data.truncate(3);
 
-    let (messages, _) = get_tpkt_tpdu_messages(&mut data);
+    let (messages, _) = get_tpkt_tpdu_messages(&data);
     assert!(messages.is_empty());
 
-    let (messages, _) = get_tpkt_tpdu_messages(&mut data);
+    let (messages, _) = get_tpkt_tpdu_messages(&data);
     assert!(messages.is_empty());
 }
 
@@ -120,11 +120,11 @@ fn reads_packet_on_second_call_after_incomplete_read() {
     let (packet_first_part, packet_second_part) = packet.split_at(3);
     let mut data = packet_first_part.to_vec();
 
-    let (messages, _) = get_tpkt_tpdu_messages(&mut data);
+    let (messages, _) = get_tpkt_tpdu_messages(&data);
     assert!(messages.is_empty());
 
     data.extend(packet_second_part);
-    let (messages, _) = get_tpkt_tpdu_messages(&mut data);
+    let (messages, _) = get_tpkt_tpdu_messages(&data);
     assert_eq!(1, messages.len());
     assert_eq!(packet.as_ref(), messages.first().unwrap().as_ref());
 }
@@ -144,7 +144,7 @@ fn reads_multiple_packets_after_incomplete_call() {
     data.extend_from_slice(second_packet_second_part);
     data.extend_from_slice(second_packet.as_ref());
     data.extend_from_slice(third_packet.as_ref());
-    let (messages, data_length) = get_tpkt_tpdu_messages(&mut data);
+    let (messages, data_length) = get_tpkt_tpdu_messages(&data);
 
     assert_eq!(2, messages.len());
     assert_eq!(first_packet.as_ref(), messages.first().unwrap().as_ref());

--- a/src/jet/association.rs
+++ b/src/jet/association.rs
@@ -1,6 +1,5 @@
 use crate::jet::candidate::{Candidate, CandidateResponse, CandidateState};
-use chrono::serde::ts_seconds;
-use chrono::{DateTime, Utc};
+use chrono::{serde::ts_seconds, DateTime, Utc};
 use indexmap::IndexMap;
 use serde_json::Value;
 use uuid::Uuid;

--- a/src/jet/candidate.rs
+++ b/src/jet/candidate.rs
@@ -10,8 +10,7 @@ use slog_scope::error;
 use url::Url;
 use uuid::Uuid;
 
-use crate::jet::TransportType;
-use crate::transport::JetTransport;
+use crate::{jet::TransportType, transport::JetTransport};
 
 #[derive(Serialize, Deserialize)]
 pub struct CandidateResponse {

--- a/src/jet_client.rs
+++ b/src/jet_client.rs
@@ -1,27 +1,35 @@
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-use std::{io, str};
+use std::{
+    collections::HashMap,
+    io, str,
+    sync::{Arc, Mutex},
+};
 
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
-use futures::future::err;
-use futures::{try_ready, Async, Future, Poll};
-use jet_proto::accept::{JetAcceptReq, JetAcceptRsp};
-use jet_proto::connect::{JetConnectReq, JetConnectRsp};
-use jet_proto::{JetMessage, JET_VERSION_V1};
-use jet_proto::{StatusCode, JET_VERSION_V2};
+use futures::{future::err, try_ready, Async, Future, Poll};
+use jet_proto::{
+    accept::{JetAcceptReq, JetAcceptRsp},
+    connect::{JetConnectReq, JetConnectRsp},
+    JetMessage, StatusCode, JET_VERSION_V1, JET_VERSION_V2,
+};
 use slog_scope::{debug, error};
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::runtime::TaskExecutor;
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    runtime::TaskExecutor,
+};
 use uuid::Uuid;
 
-use crate::config::Config;
-use crate::http::controllers::jet::create_remove_association_future;
-use crate::jet::association::Association;
-use crate::jet::candidate::{Candidate, CandidateState};
-use crate::jet::TransportType;
-use crate::transport::JetTransport;
-use crate::utils::association::{RemoveAssociation, ACCEPT_REQUEST_TIMEOUT_SEC};
-use crate::Proxy;
+use crate::{
+    config::Config,
+    http::controllers::jet::create_remove_association_future,
+    jet::{
+        association::Association,
+        candidate::{Candidate, CandidateState},
+        TransportType,
+    },
+    transport::JetTransport,
+    utils::association::{RemoveAssociation, ACCEPT_REQUEST_TIMEOUT_SEC},
+    Proxy,
+};
 
 pub type JetAssociationsMap = Arc<Mutex<HashMap<Uuid, Association>>>;
 
@@ -44,7 +52,7 @@ impl JetClient {
         let msg_reader = JetMsgReader::new(transport);
         let jet_associations = self.jet_associations.clone();
         let executor_handle = self._executor_handle.clone();
-        let config = self.config.clone();
+        let config = self.config;
 
         Box::new(msg_reader.and_then(move |(transport, msg)| match msg {
             JetMessage::JetAcceptReq(jet_accept_req) => {
@@ -183,7 +191,7 @@ impl HandleAcceptJetMsg {
         executor_handle: TaskExecutor,
     ) -> Self {
         HandleAcceptJetMsg {
-            config: config.clone(),
+            config,
             transport: Some(transport),
             request_msg: msg,
             jet_associations,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -56,7 +56,7 @@ pub fn init(file_path: Option<&String>) -> io::Result<Logger> {
 
     let env_drain = slog_envlogger::LogBuilder::new(drain_decorator)
         .filter(None, FilterLevel::Info)
-        .parse(env::var("RUST_LOG").unwrap_or(String::new()).as_str())
+        .parse(env::var("RUST_LOG").unwrap_or_default().as_str())
         .build();
 
     let drain = Async::new(env_drain.fuse())

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -89,7 +89,7 @@ impl Proxy {
             interceptor.set_message_reader(message_reader);
 
             jet_stream_server.set_packet_interceptor(Box::new(interceptor.clone()));
-            jet_stream_client.set_packet_interceptor(Box::new(interceptor.clone()));
+            jet_stream_client.set_packet_interceptor(Box::new(interceptor));
         }
 
         // Build future to forward all bytes
@@ -98,8 +98,10 @@ impl Proxy {
 
         SESSION_IN_PROGRESS_COUNT.fetch_add(1, Ordering::Relaxed);
 
-        use futures_03::compat::Future01CompatExt;
-        use futures_03::future::{FutureExt, TryFutureExt};
+        use futures_03::{
+            compat::Future01CompatExt,
+            future::{FutureExt, TryFutureExt},
+        };
 
         macro_rules! finish_remaining_forward {
             ( $fut:ident ( $stream_name:literal => $sink_name:literal ) ) => {

--- a/src/rdp/connection_sequence_future.rs
+++ b/src/rdp/connection_sequence_future.rs
@@ -246,6 +246,7 @@ impl ConnectionSequenceFuture {
 }
 
 impl Future for ConnectionSequenceFuture {
+    #[allow(clippy::type_complexity)]
     type Item = (
         Framed<TlsStream<TcpStream>, RdpTransport>,
         Framed<TlsStream<TcpStream>, RdpTransport>,

--- a/src/rdp/dvc_manager.rs
+++ b/src/rdp/dvc_manager.rs
@@ -272,7 +272,7 @@ impl CompleteData {
         total_length: usize,
         data_first: &'a [u8],
     ) -> Option<CompleteDataResult<'a>> {
-        if self.total_length != 0 || !self.data.is_none() {
+        if self.total_length != 0 || self.data.is_some() {
             error!("Incomplete DVC message, it will be skipped");
 
             self.data = None;
@@ -309,7 +309,7 @@ impl CompleteData {
                     self.data.as_mut().unwrap().extend_from_slice(data);
                     self.total_length = 0;
 
-                    self.data.take().map(|v| CompleteDataResult::Parted(v))
+                    self.data.take().map(CompleteDataResult::Parted)
                 }
                 Ordering::Greater => {
                     error!("Actual DVC message size is grater than expected total DVC message size");

--- a/src/rdp/filter.rs
+++ b/src/rdp/filter.rs
@@ -72,21 +72,23 @@ impl Filter for ClientInfoPdu {
 
 impl Filter for DemandActive {
     fn filter(&mut self, _config: &FilterConfig) {
-        self.capability_sets.retain(|capability_set| match capability_set {
-            CapabilitySet::BitmapCacheHostSupport(_)
-            | CapabilitySet::Control(_)
-            | CapabilitySet::WindowActivation(_)
-            | CapabilitySet::Share(_)
-            | CapabilitySet::Font(_)
-            | CapabilitySet::LargePointer(_)
-            | CapabilitySet::DesktopComposition(_) => false,
-            _ => true,
+        self.capability_sets.retain(|capability_set| {
+            !matches!(capability_set,
+                CapabilitySet::BitmapCacheHostSupport(_)
+                | CapabilitySet::Control(_)
+                | CapabilitySet::WindowActivation(_)
+                | CapabilitySet::Share(_)
+                | CapabilitySet::Font(_)
+                | CapabilitySet::LargePointer(_)
+                | CapabilitySet::DesktopComposition(_)
+            )
         });
 
-        if let Some(CapabilitySet::VirtualChannel(capset)) = self.capability_sets.iter_mut().find(|c| match c {
-            CapabilitySet::VirtualChannel(_) => true,
-            _ => false,
-        }) {
+        if let Some(CapabilitySet::VirtualChannel(capset)) = self
+            .capability_sets
+            .iter_mut()
+            .find(|c| matches!(c, CapabilitySet::VirtualChannel(_)))
+        {
             capset.flags = capability_sets::VirtualChannelFlags::NO_COMPRESSION;
         }
     }

--- a/src/rdp/sequence_future/dvc_capabilities.rs
+++ b/src/rdp/sequence_future/dvc_capabilities.rs
@@ -285,7 +285,7 @@ fn handle_send_data_request(
                 data_pdu.to_buffer(dvc_data.as_mut())?;
                 gfx_capabilities
                     .to_buffer(&mut dvc_data[data_pdu.buffer_length()..])
-                    .map_err(|e| map_graphics_pipeline_error(gfx::GraphicsPipelineError::from(e)))?;
+                    .map_err(map_graphics_pipeline_error)?;
 
                 Ok((DvcCapabilitiesState::Finished, dvc_data))
             }

--- a/src/rdp/sequence_future/negotiation.rs
+++ b/src/rdp/sequence_future/negotiation.rs
@@ -2,8 +2,7 @@ use std::io;
 
 use ironrdp::nego::{FailureCode, NegoData, Request, Response, ResponseData, ResponseFlags, SecurityProtocol};
 use slog_scope::debug;
-use tokio::codec::Framed;
-use tokio::net::tcp::TcpStream;
+use tokio::{codec::Framed, net::tcp::TcpStream};
 
 use super::{FutureState, NextStream, SequenceFutureProperties};
 use crate::transport::x224::{NegotiationWithClientTransport, NegotiationWithServerTransport};

--- a/src/routing_client.rs
+++ b/src/routing_client.rs
@@ -4,10 +4,11 @@ use futures::Future;
 use tokio::runtime::TaskExecutor;
 use url::Url;
 
-use crate::config::Config;
-use crate::transport::tcp::TcpTransport;
-use crate::transport::Transport;
-use crate::Proxy;
+use crate::{
+    config::Config,
+    transport::{tcp::TcpTransport, Transport},
+    Proxy,
+};
 
 pub struct Client {
     routing_url: Url,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -10,12 +10,16 @@ use std::{
 use futures::{Async, AsyncSink, Future, Poll, Sink, StartSend, Stream};
 use slog_scope::{error, trace};
 use spsc_bip_buffer::{BipBufferReader, BipBufferWriter};
-use tokio::io::{self, AsyncRead, AsyncWrite, ReadHalf, WriteHalf};
-use tokio::net::tcp::TcpStream;
+use tokio::{
+    io::{self, AsyncRead, AsyncWrite, ReadHalf, WriteHalf},
+    net::tcp::TcpStream,
+};
 use url::Url;
 
-use crate::interceptor::PacketInterceptor;
-use crate::transport::{tcp::TcpTransport, ws::WsTransport};
+use crate::{
+    interceptor::PacketInterceptor,
+    transport::{tcp::TcpTransport, ws::WsTransport},
+};
 
 pub mod fast_path;
 pub mod mcs;
@@ -44,6 +48,7 @@ pub trait Transport {
     ) -> (JetStreamType<usize>, JetSinkType<usize>);
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum JetTransport {
     Tcp(TcpTransport),
     Ws(WsTransport),
@@ -284,7 +289,7 @@ impl<T: AsyncWrite> Sink for JetSinkImpl<T> {
                 Ok(Async::NotReady) => return Ok(AsyncSink::NotReady(bytes_read)),
                 Err(e) => {
                     error!("Can't write on socket: {}", e);
-                    return Err(io::Error::from(e));
+                    return Err(e);
                 }
             }
         }

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -1,18 +1,24 @@
-use std::io::{Read, Write};
-use std::net::SocketAddr;
-use std::sync::atomic::AtomicU64;
-use std::sync::Arc;
+use std::{
+    io::{Read, Write},
+    net::SocketAddr,
+    sync::{atomic::AtomicU64, Arc},
+};
 
 use futures::{Async, Future};
 use spsc_bip_buffer::{BipBufferReader, BipBufferWriter};
-use tokio::io::{self, AsyncRead, AsyncWrite};
-use tokio::net::tcp::TcpStream;
+use tokio::{
+    io::{self, AsyncRead, AsyncWrite},
+    net::tcp::TcpStream,
+};
 use tokio_rustls::{TlsConnector, TlsStream};
 use url::Url;
 
-use crate::transport::{JetFuture, JetSinkImpl, JetSinkType, JetStreamImpl, JetStreamType, Transport};
-use crate::utils::{danger_transport, url_to_socket_arr};
+use crate::{
+    transport::{JetFuture, JetSinkImpl, JetSinkType, JetStreamImpl, JetStreamType, Transport},
+    utils::{danger_transport, url_to_socket_arr},
+};
 
+#[allow(clippy::large_enum_variant)]
 pub enum TcpStreamWrapper {
     Plain(TcpStream),
     Tls(TlsStream<TcpStream>),

--- a/src/transport/ws.rs
+++ b/src/transport/ws.rs
@@ -1,27 +1,32 @@
-use std::io::Cursor;
-use std::io::{ErrorKind, Read, Write};
-use std::net::SocketAddr;
-use std::sync::atomic::AtomicU64;
-use std::sync::Arc;
+use std::{
+    io::{Cursor, ErrorKind, Read, Write},
+    net::SocketAddr,
+    sync::{atomic::AtomicU64, Arc},
+};
 
-use futures::future;
-use futures::{Async, Future};
+use futures::{future, Async, Future};
 use hyper::upgrade::Upgraded;
 use spsc_bip_buffer::{BipBufferReader, BipBufferWriter};
-use tokio::io::{self, AsyncRead, AsyncWrite};
-use tokio::net::TcpStream;
-use tokio_rustls::TlsConnector;
-use tokio_rustls::TlsStream;
-use tungstenite::handshake::client::{Request, Response};
-use tungstenite::handshake::server::NoCallback;
-use tungstenite::handshake::MidHandshake;
-use tungstenite::protocol::Role;
-use tungstenite::Message;
-use tungstenite::{ClientHandshake, HandshakeError, ServerHandshake, WebSocket};
+use tokio::{
+    io::{self, AsyncRead, AsyncWrite},
+    net::TcpStream,
+};
+use tokio_rustls::{TlsConnector, TlsStream};
+use tungstenite::{
+    handshake::{
+        client::{Request, Response},
+        server::NoCallback,
+        MidHandshake,
+    },
+    protocol::Role,
+    ClientHandshake, HandshakeError, Message, ServerHandshake, WebSocket,
+};
 use url::Url;
 
-use crate::transport::{JetFuture, JetSinkImpl, JetSinkType, JetStreamImpl, JetStreamType, Transport};
-use crate::utils::{danger_transport, url_to_socket_arr};
+use crate::{
+    transport::{JetFuture, JetSinkImpl, JetSinkType, JetStreamImpl, JetStreamType, Transport},
+    utils::{danger_transport, url_to_socket_arr},
+};
 
 pub struct WsStream {
     inner: WsStreamWrapper,
@@ -189,6 +194,7 @@ impl AsyncWrite for WsStream {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum WsStreamWrapper {
     Http((WebSocket<Upgraded>, Option<SocketAddr>)),
     Tcp((WebSocket<TcpStream>, Option<SocketAddr>)),

--- a/src/transport/x224.rs
+++ b/src/transport/x224.rs
@@ -119,7 +119,7 @@ fn map_negotiation_error(e: NegotiationError) -> io::Error {
         ),
         NegotiationError::TpktVersionError => io::Error::new(
             io::ErrorKind::InvalidData,
-            format!("Negotiation invalid tpkt header version"),
+            "Negotiation invalid tpkt header version".to_string(),
         ),
         NegotiationError::IOError(e) => e,
     }

--- a/src/utils/association.rs
+++ b/src/utils/association.rs
@@ -1,5 +1,4 @@
-use crate::jet::candidate::CandidateState;
-use crate::jet_client::JetAssociationsMap;
+use crate::{jet::candidate::CandidateState, jet_client::JetAssociationsMap};
 use futures::{Async, Future};
 use slog_scope::debug;
 use uuid::Uuid;

--- a/src/websocket_client.rs
+++ b/src/websocket_client.rs
@@ -316,7 +316,7 @@ fn process_req(req: &Request<Body>) -> Response<Body> {
 }
 
 fn get_uuid_in_path(path: &str, index: usize) -> Option<Uuid> {
-    if let Some(raw_uuid) = path.split("/").skip(index + 1).next() {
+    if let Some(raw_uuid) = path.split('/').nth(index + 1) {
         Uuid::parse_str(raw_uuid).ok()
     } else {
         None

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,6 +1,8 @@
-use std::env;
-use std::path::PathBuf;
-use std::process::{Child, Command};
+use std::{
+    env,
+    path::PathBuf,
+    process::{Child, Command},
+};
 
 fn bin() -> PathBuf {
     let mut me = env::current_exe().unwrap();

--- a/tests/jet_client.rs
+++ b/tests/jet_client.rs
@@ -1,16 +1,17 @@
 mod common;
 
 use jet_proto::JetMessage;
-use std::io::{Read, Write};
-use std::net::TcpStream;
-use std::sync::mpsc::channel;
-use std::thread;
-use std::time::Duration;
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
+    sync::mpsc::channel,
+    thread,
+    time::Duration,
+};
 use uuid::Uuid;
 
 use common::run_proxy;
-use jet_proto::accept::JetAcceptReq;
-use jet_proto::connect::JetConnectReq;
+use jet_proto::{accept::JetAcceptReq, connect::JetConnectReq};
 use reqwest::{Client, StatusCode};
 use serde_derive::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -63,7 +64,7 @@ fn smoke_tcp_v1() {
                                         sender_uuid.send(rsp.association).unwrap();
                                     }
                                     _ => {
-                                        assert!(false, "Wrong message type received");
+                                        panic!("Wrong message type received");
                                     }
                                 }
                                 break;
@@ -133,7 +134,7 @@ fn smoke_tcp_v1() {
                                         assert!(rsp.version == 1);
                                     }
                                     _ => {
-                                        assert!(false, "Wrong message type received");
+                                        panic!("Wrong message type received");
                                     }
                                 }
                                 break;
@@ -245,7 +246,7 @@ fn smoke_tcp_v2() {
                                         sender_synchro.send(()).unwrap();
                                     }
                                     _ => {
-                                        assert!(false, "Wrong message type received");
+                                        panic!("Wrong message type received");
                                     }
                                 }
                                 break;
@@ -288,7 +289,7 @@ fn smoke_tcp_v2() {
         loop {
             match TcpStream::connect(proxy_addr) {
                 Ok(mut stream) => {
-                    let _ = receiver_synchro.recv().unwrap();
+                    receiver_synchro.recv().unwrap();
 
                     // Send request
                     let jet_message = JetMessage::JetConnectReq(JetConnectReq {
@@ -315,7 +316,7 @@ fn smoke_tcp_v2() {
                                         assert!(rsp.version == 2);
                                     }
                                     _ => {
-                                        assert!(false, "Wrong message type received");
+                                        panic!("Wrong message type received");
                                     }
                                 }
                                 break;

--- a/tests/rdp.rs
+++ b/tests/rdp.rs
@@ -80,7 +80,10 @@ fn run_client() -> Child {
     client_command.spawn().unwrap_or_else(|e| panic!("{:?}", e))
 }
 
+// NOTE: The following test is disabled by default as it requires specific environment with
+// ironrdp_client executable in PATH variable
 #[test]
+#[ignore]
 fn rdp_with_nla_ntlm() {
     let mut identities_file = tempfile::NamedTempFile::new().expect("failed to create a named temporary file");
     let rdp_identities = vec![RdpIdentity::new(

--- a/tests/rdp.rs
+++ b/tests/rdp.rs
@@ -77,7 +77,7 @@ fn run_client() -> Child {
         client_command.args(&["--domain", domain]);
     }
 
-    client_command.spawn().unwrap_or_else(|e| panic!("{:?}", e))
+    client_command.spawn().expect("failed to run IronRDP client")
 }
 
 // NOTE: The following test is disabled by default as it requires specific environment with

--- a/tests/routing_client.rs
+++ b/tests/routing_client.rs
@@ -1,11 +1,12 @@
 mod common;
 
-use std::io::{Read, Write};
-use std::net::SocketAddr;
-use std::net::{TcpListener, TcpStream};
-use std::sync::mpsc::channel;
-use std::thread;
-use std::time::Duration;
+use std::{
+    io::{Read, Write},
+    net::{SocketAddr, TcpListener, TcpStream},
+    sync::mpsc::channel,
+    thread,
+    time::Duration,
+};
 
 use common::run_proxy;
 


### PR DESCRIPTION
This PR fixed multiple Clippy warnings which are causing test.sh CI script to fail.

Also this PR sets rdp_with_nla_ntlm integration test as #[ignored]; 
This test fails because it requires that the test environment should have an ironrdp_client application in PATH, which is not usually the case. Maybe separate refactoring for this test is required to eliminate the additional environment dependencies. 

Note that out Travis CI is still looks broken and should be fixed, builds are not triggered automatically, and last builds (~9-10 months ago) were failed (mostly because of the problems which were solved in this PR). 